### PR TITLE
Upgrade Pillow to 7.1.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -17,7 +17,7 @@ more-itertools==8.2.0
 networkx==2.1
 numpy==1.16.4
 packaging==20.3
-Pillow==6.2.2
+Pillow==7.1.0
 pluggy==0.13.1
 py==1.8.1
 pylint==2.4.4


### PR DESCRIPTION
Due to

- CVE-2020-11538
- CVE-2020-10177
- CVE-2020-10994
- CVE-2020-10379

Closes #6