### PR TITLE
Reduce Concurrency

### DIFF
--- a/src/app.yaml
+++ b/src/app.yaml
@@ -25,6 +25,11 @@ instance_class: F4
 
 automatic_scaling:
   min_instances: {{MIN_INSTANCES}}
+  # The below will mean that at max * target will
+  # trigger a new instance to be scheduled
+  target_throughput_utilization: 0.5 # Default
+  max_concurrent_requests: 3
+
 
 inbound_services:
   - warmup


### PR DESCRIPTION
By reducing the Concurrency it should allow the longer running
tasks more chance to complete.

This isn't a fix, more to see if it reduces the frequency of 502s
while a proper fix is put in place.

Relates to #17